### PR TITLE
Add Dockerfile for beeweb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang
+MAINTAINER astaxie xiemengjun@gmail.com
+
+RUN go get github.com/astaxie/beego
+
+RUN go get github.com/beego/beeweb
+
+WORKDIR /go/src/github.com/beego/beeweb
+
+RUN go build
+
+EXPOSE 8080
+
+CMD ["./beeweb"]


### PR DESCRIPTION
After adding the Dockerfile, we can add an automated build for this repository in docker hub. Then everyone can run `docker run -d -p 8080:8080 beego/beeweb` to deploy beeweb in localhost without installing golang or configuring anything.

The Dockerfile works like a charm in my local host. You can build the image from the local file for testing.
