### PR TITLE
fix: fix invalid memory address or nil pointer dereference

### DIFF
--- a/models/press.go
+++ b/models/press.go
@@ -132,12 +132,14 @@ func (d *DocRoot) walkParse() error {
 }
 
 func (d *DocRoot) sortAll(node *DocNode) {
-	for _, n := range node.Docs {
-		if n.IsDir {
-			d.sortAll(n)
+	if node != nil {
+		for _, n := range node.Docs {
+			if n.IsDir {
+				d.sortAll(n)
+			}
 		}
+		node.SortDocs()
 	}
-	node.SortDocs()
 }
 
 func (d *DocRoot) makeDirNode(path string) error {


### PR DESCRIPTION
初次运行beeweb时候，文档的 *Tree json文件还未生成之前，docs内还没有markdown文件的时候，会导致无法启动。
```
songgl@MBP-SONGGL-2:~/codes/goCode/src/github.com/beego/beeweb(branch::master)$ ./beeweb
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x1438166]

goroutine 1 [running]:
github.com/beego/beeweb/models.(*DocRoot).sortAll(0xc420115440, 0x0)
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/models/press.go:135 +0x26
github.com/beego/beeweb/models.(*DocRoot).walkParse.func1(0xc42004dce0, 0xc420115440)
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/models/press.go:126 +0x4b
github.com/beego/beeweb/models.(*DocRoot).walkParse(0xc420115440, 0x0, 0x0)
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/models/press.go:131 +0x139
github.com/beego/beeweb/models.ParseDocs(0x1559aaf, 0xa, 0xc42015f8a0, 0x0, 0x17d5320)
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/models/press.go:337 +0xb1
github.com/beego/beeweb/models.parseDocs()
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/models/models.go:105 +0x48
github.com/beego/beeweb/models.InitModels()
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/models/models.go:85 +0x16b
main.initialize()
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/beeweb.go:36 +0x26
main.main()
	/Users/songgl/work/codes/goCode/src/github.com/beego/beeweb/beeweb.go:50 +0x34
```